### PR TITLE
Try using Bundler 1.15.4 to avoid Travis error

### DIFF
--- a/tests/install.sh
+++ b/tests/install.sh
@@ -5,5 +5,7 @@ pip install flake8 json-merge-patch jsonschema "pytest<3" requests
 
 # Ruby dependencies
 curl -s -S -o /tmp/Gemfile $BASEDIR/fixtures/Gemfile
-gem install bundler
-bundle install --gemfile=/tmp/Gemfile --path /tmp/vendor/bundle --binstubs=/tmp/bin
+# Use same magic incantation as https://github.com/rails/rails/blob/288fbc7ff47b6aae0d5bab978ae16858a425f643/.travis.yml#L30-L31
+gem update --system
+gem install bundler -v 1.15.4
+bundle _1.15.4_ install --gemfile=/tmp/Gemfile --path /tmp/vendor/bundle --binstubs=/tmp/bin


### PR DESCRIPTION
```
Fetching https://github.com/markdownlint/markdownlint.git
Fetching gem metadata from https://rubygems.org/.
Resolving dependencies...
Using bundler 1.16.0
Errno::ENOENT: No such file or directory @ rb_sysopen -
/home/travis/.rvm/rubies/ruby-2.4.1/lib/ruby/site_ruby/2.4.0/bundler/templates/Executable.bundler
An error occurred while installing bundler (1.16.0), and Bundler
cannot continue.
```

Closes #30 