### PR TITLE
Revert pytest change

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ The standard [`.travis.yml`](fixtures/.travis.yml) file performs:
 To run the tests locally, run the setup commands above, change into a repository's folder, then:
 
     flake8 --max-line-length 119
-    pytest -rs path/to/standard-maintenance-scripts/tests
+    py.test -rs path/to/standard-maintenance-scripts/tests
 
 To run the tests locally against an unreleased version of the standard, replace `http://standard.open-contracting.org/schema/VERSION` with `http://standard.open-contracting.org/BRANCH/en`.
 

--- a/tests/script.sh
+++ b/tests/script.sh
@@ -12,4 +12,4 @@ flake8 --max-line-length 119
 # Validate CSV, JSON and JSON Schema
 curl -s -S --retry 3 -o /tmp/test_csv.py $BASEDIR/tests/test_csv.py
 curl -s -S --retry 3 -o /tmp/test_json.py $BASEDIR/tests/test_json.py
-pytest -rs --tb=line /tmp/test_csv.py /tmp/test_json.py
+py.test -rs --tb=line /tmp/test_csv.py /tmp/test_json.py


### PR DESCRIPTION
Currently 1.1-dev of standard repo is broken on travis because of this.

Using py.test is more backward compatible with different versions of pytest and as this repo does not specify fixed versions any more it will break any repo with an older fixed version.