### PR TITLE
Add "schemas" to extension-schema.json

### DIFF
--- a/schema/extension-schema.json
+++ b/schema/extension-schema.json
@@ -69,6 +69,20 @@
         }
       }
     },
+    "schemas": {
+      "title": "Extension schemas",
+      "description": "JSON Schema Patch files in this extension.",
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "enum": [
+          "record-package-schema.json",
+          "release-package-schema.json",
+          "release-schema.json"
+        ]
+      }
+    },
     "dependencies": {
       "title": "Dependencies",
       "description": "Extensions this extension depends on.",

--- a/tasks/local.rake
+++ b/tasks/local.rake
@@ -119,6 +119,7 @@ Report issues for this extension in the [ocds-extensions repository](https://git
       repo_name = File.basename(path)
 
       if Dir.exist?(path) && extension?(repo_name)
+        full_name = File.read(File.join(path, '.git', 'config')).match(/git@github.com:(\S+)\.git/)[1]
         file_path = File.join(path, 'extension.json')
         content = JSON.load(File.read(file_path))
         expected = Marshal.load(Marshal.dump(content))
@@ -145,13 +146,19 @@ Report issues for this extension in the [ocds-extensions repository](https://git
         end
 
         if !content.key?('documentationUrl')
-          content['documentationUrl'] = { 'en' => "https://github.com/open-contracting/#{repo_name}" }
+          content['documentationUrl'] = { 'en' => "https://github.com/#{full_name}" }
         end
 
         codelists = Set.new(Dir[File.join(path, 'codelists', '*')].map{ |path| File.basename(path) })
 
         if String === content['codelists'] || codelists != Set.new(content['codelists'])
           content['codelists'] = codelists.to_a.sort
+        end
+
+        schemas = Set.new(Dir[File.join(path, '*-schema.json')].map{ |path| File.basename(path) })
+
+        if String === content['schemas'] || schemas != Set.new(content['schemas'])
+          content['schemas'] = schemas.to_a.sort
         end
 
         if expected != content

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -816,7 +816,8 @@ def test_extension_json():
         url = 'https://raw.githubusercontent.com/open-contracting/standard-maintenance-scripts/master/schema/extension-schema.json'  # noqa
         schema = requests.get(url).json()
 
-    expected = {os.path.basename(path) for path, _ in walk_csv_data(os.path.join(cwd, 'codelists'))}
+    expected_codelists = {os.path.basename(path) for path, _ in walk_csv_data(os.path.join(cwd, 'codelists'))}
+    expected_schemas = {os.path.basename(path) for path, _, _ in walk_json_data()} - {'extension.json'}
 
     path = os.path.join(cwd, 'extension.json')
     if os.path.isfile(path):
@@ -825,7 +826,8 @@ def test_extension_json():
 
         validate_json_schema(path, data, schema)
 
-        urls = data.get('dependencies', []) + list(data['documentationUrl'].values())
+        urls = data.get('dependencies', []) + data.get('testDependencies', []) + \
+            list(data['documentationUrl'].values())
         for url in urls:
             try:
                 status_code = requests.head(url).status_code
@@ -833,12 +835,17 @@ def test_extension_json():
             except requests.exceptions.ConnectionError as e:
                 assert False, '{} on {}'.format(e, url)
 
-        actual = set(data.get('codelists', []))
-        if actual != expected:
-            added, removed = difference(actual, expected)
+        actual_codelists = set(data.get('codelists', []))
+        if actual_codelists != expected_codelists:
+            added, removed = difference(actual_codelists, expected_codelists)
             assert False, '{} has mismatch with schema{}{}'.format(
                 path, added, removed)
 
+        actual_schemas = set(data.get('schemas', []))
+        if actual_schemas != expected_schemas:
+            added, removed = difference(actual_schemas, expected_schemas)
+            assert False, '{} has mismatch with schema{}{}'.format(
+                path, added, removed)
     else:
         assert False, 'expected an extension.json file'
 


### PR DESCRIPTION
This issue is motivated by the following:

1. It is not possible for a service to determine which core schema files an extension patches without testing all three possible URLs (`http…/release-schema.json`, etc.)
1. We would like it to be possible for a service to determine which core schema files an extension patches without doing this sort of URL discovery
1. JSON Schema Patch files in extensions are optional (see https://github.com/open-contracting/standard_extension_template/issues/29)
1. We would like CoVE to display an appropriate error if an explicitly expected patch file is missing, but not error otherwise

As background:

* In https://github.com/open-contracting/ocds-extensions/issues/59, I proposed adding a `schemas` field to extension.json similar to the `codelists` field.
* In https://github.com/open-contracting/standard_extension_template/issues/29#issuecomment-391134423, I proposed that CoVE's behavior should be to error if it tries to fetch a schema listed in `schemas` and fails, but report no error if there are no `schemas` specified and it fails to optimistically retrieve the release schema.

If this issue is agreed, I can merge this and then use the local:extension_json task it contains to update all extension repositories, as I've done in the past for other changes to all extensions.

Requesting review from one of @duncandewhurst @kindly @timgdavies