### PR TITLE
Add codelist titles conversion task

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,6 +242,10 @@ Make local changes to multiple extensions:
 
     bundle exec rake local:extension_json BASEDIR=../path/to/directory/of/extensions
 
+Convert codelist titles to sentence case locally:
+
+    bundle exec rake local:codelist_titles BASEDIR=../path/to/directory/of/extensions
+
 Lists web traffic statistics over past two weeks:
 
     bundle exec rake repos:traffic

--- a/tasks/local.rake
+++ b/tasks/local.rake
@@ -14,6 +14,16 @@ namespace :local do
     end
   end
 
+  def get_extension_ids
+    extension_ids = {}
+    url = 'https://raw.githubusercontent.com/open-contracting/extension_registry/master/build/extensions.json'
+    JSON.load(open(url).read)['extensions'].each do |extension|
+      full_name = extension['url'][%r{\Ahttps://raw\.githubusercontent\.com/([^/]+/[^/]+)}, 1]
+      extension_ids[full_name] = extension['id']
+    end
+	extension_ids
+  end
+
   REPOSITORY_CATEGORIES_WITHOUT_DOCS = [
     'Specifications',
     'Guides',
@@ -98,12 +108,7 @@ namespace :local do
 
   desc 'Update extension.json'
   task :extension_json do
-    extension_ids = {}
-    url = 'https://raw.githubusercontent.com/open-contracting/extension_registry/master/build/extensions.json'
-    JSON.load(open(url).read)['extensions'].each do |extension|
-      full_name = extension['url'][%r{\Ahttps://raw\.githubusercontent\.com/([^/]+/[^/]+)}, 1]
-      extension_ids[full_name] = extension['id']
-    end
+	extension_ids = get_extension_ids
 
     each_path do |path, updated|
       repo_name = File.basename(path)
@@ -129,6 +134,33 @@ namespace :local do
           updated << repo_name
           File.open(file_path, 'w') do |f|
             f.write(JSON.pretty_generate(content) + "\n")
+          end
+        end
+      end
+    end
+  end
+
+  desc 'Convert codelist titles to Sentence case'
+  task :codelist_titles do
+
+	extension_ids = get_extension_ids
+
+    each_path do |path, updated|
+      repo_name = File.basename(path)
+	  codelist_folder = File.join(path, 'codelists')
+
+      if Dir.exist?(path) && extension?(repo_name) && !profile?(repo_name) && Dir.exists?(codelist_folder)
+	    Dir[File.join(codelist_folder,'*.csv')].each do |filename|
+          original = File.read(filename)
+          table = CSV.parse(original, headers: true)
+          if table.headers.include? 'Title'
+            table.each do |row|
+              row["Title"] = row["Title"].capitalize
+            end
+          end
+          if original != table.to_s
+            puts "File #{filename} changed!"
+            File.write(filename, table)
           end
         end
       end


### PR DESCRIPTION
Ref https://github.com/open-contracting/ocds-extensions/issues/100

I've added a rake task to update codelist titles to sentence case, following a similar logic as the `local:extension_json` task.

When testing I noticed that not all titles should be changed to sentence case, like some codelists under the OCDS for PPPs, so a manual review is required (there isn't many files, I counted 11 from all extensions under the open-contracting-extensions organization).