### PR TITLE
script: Add -x so that the command being run can be seen in output

### DIFF
--- a/tests/script.sh
+++ b/tests/script.sh
@@ -1,4 +1,4 @@
-set -e
+set -xe
 
 # Ignore version control, untracked files and executable scripts.
 ! find . -type f \! -perm 644 \! -path '*/.git/*' \! -path '*/.tox/*' \! -path '*/__pycache__/*' \! -path '*/cache/*' \


### PR DESCRIPTION
When multiple commands are in the same script knowing which error
message came from which command is helpful as well being able to see
the parameters used.